### PR TITLE
Robustness pass

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ test_rle: test_rle.c $(RLE_VARIANT_HEADERS) utility.h
 test_utility: test_utility.c utility.h
 	$(CC) $(CFLAGS) $< $(filter %.o, $^) -o $@
 
+test_example: rle_packbits.h
+
 test: test_rle test_utility test_example
 	$(TEST_PREFIX) ./test_utility
 	$(TEST_PREFIX) ./test_rle

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 A collection of Run-Length Encoders and Decoders, and associated tooling for exploring this space. So far there are only three animals in the zoo. It's a very small zoo.
 
 * _WHILE THIS NOTE PERSISTS, I MAY FORCE PUSH TO MASTER_
-* The codecs are written foremost to be clear and easy to understand, not for speed.
+* The codecs are written foremost to be robust, correct, and clear and easy to understand, not for performance.
 * I'm mostly interested in exploring legacy formats.
 
 ## What is Run-Length Encoding?
@@ -29,8 +29,8 @@ int main(void) {
 	const uint8_t input[] = "ABBBBA";
 	size_t len = sizeof(input) - 1;
 
-	// Call with NULL for dest buffer and size to calculate output size.
-	size_t expected_size = packbits_compress(input, len, NULL, 0);
+	// Call with NULL for dest buffer to calculate output size.
+	ssize_t expected_size = packbits_compress(input, len, NULL, 0);
 	...
 ```
 
@@ -56,7 +56,7 @@ Currently the following extraordinary specimens are grazing the fertile grounds 
 
 ### PackBits
 
-The `packbits` variant reportedly originates from the Apple Macintosh[^fnTN1023], but spread far and wide from there, including
+The `packbits` variant reportedly originates from the Apple Macintosh[^foottn1023], but spread far and wide from there, including
 into Electronic Arts IFF ILBM (unverified).
 
 #### PackBits Format
@@ -80,7 +80,7 @@ into Electronic Arts IFF ILBM (unverified).
 The encoder should not generate 0x80, which is reserved. The technical note from Apple states that a decoder should
 "_[handle] this situation by skipping any flag-counter byte with this value and interpreting the next byte as the next flag-counter byte._"
 
-[^fnTN1023]: "Understanding PackBits", Apple [Technical Note TN1023](http://web.archive.org/web/20080705155158/http://developer.apple.com/technotes/tn/tn1023.html).
+[^foottn1023]: "Understanding PackBits", Apple [Technical Note TN1023](http://web.archive.org/web/20080705155158/http://developer.apple.com/technotes/tn/tn1023.html).
 
 ### Goldbox
 
@@ -155,7 +155,6 @@ The existance of a `REP 0` operation is an inefficiency, and allows the encoder 
 
 ## TODO
 
-* Improve handling of invalid input (return error value?), e.g REP/CPY OP as last input byte.
 * Add more animals. Potential candidates: Apple 'icns' Icons, BMP(?), TGA, ...
 * Add fuzzing (afl++).
 * Improve `rle-zoo` to behave more like a standard UNIX filter.

--- a/rle-tests.suite
+++ b/rle-tests.suite
@@ -61,6 +61,7 @@ packbits c @tests/packbits/tn1023 15 0x8b25afe0
 packbits d @tests/packbits/tn1023.rle 24 0xef6fc26a
 packbits d @tests/packbits/R128A.rle 128 0x30a4907a
 packbits d @tests/packbits/R128A_C128_R128A.rle 384 0xcf8b3f17
+packbits d- "\x80\xFFA\x80\x80" 2 0xaec4b71e
 
 pcx c "A" 1 0xe16dcdee
 pcx c "AA" 2 0x61e0e57e
@@ -82,3 +83,12 @@ pcx c @tests/R128_FF 6 0x7113a0bd
 
 # REP 0 can be used to hide things from the decoder. Roundtrip check disabled.
 pcx d- "\xC0s\xC0e\xC0c\xC0r\xC0e\xC0tmessage" 7 0x98a214d0
+
+## Invalid input examples:
+## REP 2 at end
+goldbox d "\xfe" -2
+packbits d "\xff" -2
+pcx d "\xc2" -2
+## CPY 2 at end
+goldbox d "\x01" -2
+packbits d "\x01" -2

--- a/rle-zoo.c
+++ b/rle-zoo.c
@@ -20,7 +20,7 @@
 #include "rle_pcx.h"
 
 // TODO: Variant selection code + tables can be shared.
-typedef size_t (*rle_fp)(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
+typedef ssize_t (*rle_fp)(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
 
 struct rle_t {
 	const char *name;
@@ -114,14 +114,16 @@ static void rle_compress_file(const char *srcfile, const char *destfile, rle_fp 
 			err(1, "fread: %s", srcfile);
 		}
 
-		size_t clen = compress_func(src, slen, NULL, 0);
-		if (clen > 0) {
+		ssize_t clen = compress_func(src, slen, NULL, 0);
+		if (clen >= 0) {
 			uint8_t *dest = malloc(clen);
 			clen = compress_func(src, slen, dest, clen);
 
 			fwrite(dest, clen, 1, ofile);
 
 			printf("%zd bytes written to output.\n", clen);
+		} else {
+			printf("Compression error: %zd\n", clen);
 		}
 
 		fclose(ofile);
@@ -155,14 +157,16 @@ static void rle_decompress_file(const char *srcfile, const char *destfile, rle_f
 				err(1, "fread: %s", srcfile);
 			}
 
-			size_t dlen = decompress_func(src, slen, NULL, 0);
-			if (dlen > 0) {
+			ssize_t dlen = decompress_func(src, slen, NULL, 0);
+			if (dlen >= 0) {
 				uint8_t *dest = malloc(dlen);
 				dlen = decompress_func(src, slen, dest, dlen);
 
 				fwrite(dest, dlen, 1, ofile);
 
 				printf("%zd bytes written to output.\n", dlen);
+			} else {
+				printf("Decompression error: %zd\n", dlen);
 			}
 
 			fclose(ofile);

--- a/rle_packbits.h
+++ b/rle_packbits.h
@@ -10,21 +10,23 @@ extern "C" {
 
 #include <stdint.h>
 #include <stddef.h>
+#include <sys/types.h> // ssize_t
 
-size_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
-size_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
+ssize_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
+ssize_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
 
 #ifdef RLE_ZOO_PACKBITS_IMPLEMENTATION
 #include <assert.h>
 
 // RLE PARAMS: min CPY=1, max CPY=128, min REP=2, max REP=128
-size_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
+ssize_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
 	size_t rp = 0;
 	size_t wp = 0;
 
-	while (rp < slen && (wp < dlen || dest == NULL)) {
+	while (rp < slen) {
 		uint8_t cnt = 0;
 
+		// TODO: Replace with do-while...
 		// Count number of same bytes, up to 128
 		while ((rp+cnt+1 < slen) && (src[rp+cnt] == src[rp+cnt+1]) && (cnt < 127)) {
 			++cnt;
@@ -34,10 +36,13 @@ size_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t 
 		// Output REP.
 		if (cnt > 1) {
 			assert(cnt >= 2 && cnt <= 128);
-			if (dest && dlen > 0) {
-				dest[wp+0] = 257 - cnt;
-				if (wp + 1 < dlen)
+			if (dest) {
+				if (wp + 1 < dlen) {
+					dest[wp+0] = 257 - cnt;
 					dest[wp+1] = src[rp];
+				} else {
+					return -(rp+1); // Destination buffer too small
+				}
 			}
 			wp += 2;
 			rp += cnt;
@@ -51,13 +56,17 @@ size_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t 
 
 		assert(cnt > 0);
 		assert(cnt <= 128);
+		assert(rp + cnt <= slen);
 
 		// Output CPY
-		if (dest && dlen > 0) {
-			dest[wp+0] = cnt - 1;
-			// memcpy(dest+wp+1, src+rp, cnt);
-			for (int i = 0 ; i < cnt && wp + 1 + i < dlen ; ++i)
-				dest[wp + 1 + i] = src[rp + i];
+		if (dest) {
+			if (wp + cnt + 1 <= dlen) {
+				dest[wp] = cnt - 1;
+				for (int i = 0 ; i < cnt ; ++i)
+					dest[wp + 1 + i] = src[rp + i];
+			} else {
+				return -(rp+1);
+			}
 		}
 		rp += cnt;
 		wp += cnt + 1;
@@ -67,38 +76,49 @@ size_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t 
 	return wp;
 }
 
-size_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
-	const uint8_t *send = src + slen;
+ssize_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
 	size_t wp = 0;
-	while (src < send && (wp < dlen || dest == NULL)) {
-		uint8_t cnt;
-		uint8_t b = *src++;
+	size_t rp = 0;
+	while (rp < slen) {
+		uint8_t cnt = 0;
+		uint8_t b = src[rp++];
 		if (b > 0x80) {
 			// REP
 			cnt = 257 - b;
-			if (dest && dlen > 0) {
-				// memset(dest + wp, *src, cnt);
-				for (int i = 0 ; i < cnt && wp + i < dlen ; ++i)
-					dest[wp + i] = *src;
+			if (!(rp < slen)) {
+				return -(rp +1);
 			}
-			++src;
+			if (dest) {
+				if (wp + cnt <= dlen) {
+					for (int i = 0 ; i < cnt ; ++i)
+						dest[wp + i] = src[rp];
+				} else {
+					return -(rp + 1);
+				}
+			}
+			++rp;
 		} else if (b < 0x80) {
 			// CPY
 			cnt = b + 1;
-			if (dest && dlen > 0) {
-				// memcpy(dest + wp, src, cnt);
-				for (int i = 0 ; i < cnt && wp + i < dlen ; ++i)
-					dest[wp + i] = src[i];
+			if (!(rp + cnt <= slen)) {
+				return -(rp +1);
 			}
-			src += cnt;
+			if (dest) {
+				if (wp + cnt <= dlen) {
+					for (int i = 0 ; i < cnt ; ++i)
+						dest[wp + i] = src[rp + i];
+				} else {
+					return -(rp + 1);
+				}
+			}
+			rp += cnt;
 		} else {
 			// 0x80 is reserved, skip byte as suggested by TN1023.
-			++src;
-			cnt = 0;
+			// cnt = 0;
 		}
 		wp += cnt;
 	}
-	assert(src == send);
+	assert(rp == slen);
 	assert((dest == NULL) || (wp <= dlen));
 	return wp;
 }

--- a/rle_pcx.h
+++ b/rle_pcx.h
@@ -10,18 +10,19 @@ extern "C" {
 
 #include <stdint.h>
 #include <stddef.h>
+#include <sys/types.h> // ssize_t
 
-size_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
-size_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
+ssize_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
+ssize_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen);
 
 #ifdef RLE_ZOO_PCX_IMPLEMENTATION
 #include <assert.h>
 
-size_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
+ssize_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
 	size_t rp = 0;
 	size_t wp = 0;
 
-	while (rp < slen && (wp < dlen || dest == NULL)) {
+	while (rp < slen) {
 		size_t cnt = 0;
 		// size_t cnt = rle_count_rep(src + rp, slen - rp, 63);
 		do { ++cnt; } while ((rp + cnt < slen) && (cnt < 63) && (src[rp + cnt - 1] == src[rp + cnt]));
@@ -29,18 +30,25 @@ size_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen)
 		// Output REP, also include any bytes that can't be encoded as a LIT.
 		if (cnt > 1 || ((src[rp] & 0xC0) == 0xC0)) { // or >= 192
 			assert(cnt <= 63);
-			if (dest && dlen > 0) {
-				dest[wp] = 0xC0 | cnt;
-				if (wp + 1 < dlen)
-					dest[wp + 1] = src[rp];
+			if (dest) {
+				if (wp + 1 < dlen) {
+					dest[wp+0] = 0xC0 | cnt;
+					dest[wp+1] = src[rp];
+				} else {
+					return -(rp+1); // Destination buffer too small
+				}
 			}
 			wp += 2;
 			rp += cnt;
 		} else {
 			// Output LIT.
 			// PERF: Again, this is probably suboptimal, and also results in encoding runs of 2 LITs as REP, which differs from IM encoder.
-			if (dest && dlen > 0) {
-				dest[wp] = src[rp];
+			if (dest) {
+				if (wp < dlen) {
+					dest[wp] = src[rp];
+				} else {
+					return -(rp+1);
+				}
 			}
 			++rp;
 			++wp;
@@ -51,25 +59,32 @@ size_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen)
 	return wp;
 }
 
-size_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
-	const uint8_t *send = src + slen;
+ssize_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
 	size_t wp = 0;
-	while (src < send && (wp < dlen || dest == NULL)) {
+	size_t rp = 0;
+	while (rp < slen) {
 		uint8_t cnt = 1;
-		uint8_t b = *src++;
+		uint8_t b = src[rp++];
 
 		// REP
 		if ((b & 0xC0) == 0xC0) {
+			if (!(rp < slen)) {
+				return -(rp + 1);
+			}
 			cnt = b & 0x3F;
-			b = (src < send) ? *src++ : 0; // Guard from OOB read
+			b = src[rp++];
 		}
 		if (dest) {
-			for (int i = 0 ; i < cnt && wp + i < dlen ; ++i)
-				dest[wp + i] = b;
+			if (wp + cnt <= dlen) {
+				for (int i = 0 ; i < cnt ; ++i)
+					dest[wp + i] = b;
+			} else {
+				return -(rp + 1);
+			}
 		}
 		wp += cnt;
 	}
-	assert(src == send);
+	assert(rp == slen);
 	assert((dest == NULL) || (wp <= dlen));
 	return wp;
 }

--- a/test_example.c
+++ b/test_example.c
@@ -12,27 +12,29 @@
 #include "rle_packbits.h"
 
 int main(void) {
-	const uint8_t input[] = "ABBBBA";
+	const uint8_t input[] = "ABBCCCDDDDEEEEE";
 	size_t len = sizeof(input) - 1;
 
-	// Call with NULL for dest buffer and size to calculate output size.
-	size_t compressed_size = packbits_compress(input, len, NULL, 0);
+	// Call with NULL for dest buffer to calculate output size.
+	ssize_t compressed_size = packbits_compress(input, len, NULL, 0);
 
 	if (compressed_size > 0) {
 		uint8_t *output = malloc(compressed_size);
 		if (output) {
-			packbits_compress(input, len, output, compressed_size);
-			printf("Compressed '%s' into %zu bytes: ", input, compressed_size);
+			ssize_t res = packbits_compress(input, len, output, compressed_size);
+			if (res > 0) {
+				printf("Compressed '%s' (%zu bytes) into %zd bytes: ", input, len, compressed_size);
 
-			// Do something with the output.
-			for (size_t i = 0 ; i < compressed_size ; ++i) {
-				printf("%02X ", output[i]);
+				// Do something with the output.
+				for (int i = 0 ; i < res ; ++i) {
+					printf("%02X ", output[i]);
+				}
+				printf("\n");
+			} else {
+				printf("Compression error: %zd\n", res);
 			}
-			printf("\n");
-
 			free(output);
 		}
 	}
-
 	return 0;
 }


### PR DESCRIPTION
Improve robustness by changing return value from
`size_t` to `ssize_t` and having the codecs return
negative values on errors.

Update all the driver/example code to handle the new interface.

Add a few basic invalid-input tests to the test suite.