### PR TITLE
Make rle_*.h build under -Wconversion

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ test_example: rle_packbits.h
 test_includeall: test_includeall.c $(RLE_VARIANT_HEADERS)
 	$(CC) $(CFLAGS) $(STRICT_FLAGS) test_includeall.c
 
-test: test_rle test_utility test_example test_includeall
+test: test_rle test_utility test_example
 	$(TEST_PREFIX) ./test_utility
 	$(TEST_PREFIX) ./test_rle
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ WARNFLAGS=-Wall -Wextra -Wshadow -Wstrict-aliasing -Wcast-qual -Wcast-align -Wpo
 CWARNFLAGS=-Wstrict-prototypes -Wmissing-prototypes
 MISCFLAGS=-fstack-protector -fvisibility=hidden
 DEVFLAGS=-ggdb -DDEBUG -Wno-unused
+STRICT_FLAGS=-Werror -Wconversion
 
 RLE_VARIANTS:=goldbox packbits pcx
 RLE_VARIANT_HEADERS:=$(addprefix rle_, $(RLE_VARIANTS:=.h))
@@ -55,7 +56,10 @@ test_utility: test_utility.c utility.h
 
 test_example: rle_packbits.h
 
-test: test_rle test_utility test_example
+test_includeall: test_includeall.c $(RLE_VARIANT_HEADERS)
+	$(CC) $(CFLAGS) $(STRICT_FLAGS) test_includeall.c
+
+test: test_rle test_utility test_example test_includeall
 	$(TEST_PREFIX) ./test_utility
 	$(TEST_PREFIX) ./test_rle
 
@@ -71,4 +75,4 @@ backup:
 
 clean:
 	@echo -e $(YELLOW)Cleaning$(NC)
-	rm -f rle-zoo rle-genops rle-parser test_rle test_utility test_example $(RLE_VARIANT_OPS_HEADERS) vgcore.* core.* *.gcda
+	rm -f rle-zoo rle-genops rle-parser test_rle test_utility test_example test_includeall $(RLE_VARIANT_OPS_HEADERS) vgcore.* core.* *.gcda

--- a/rle_goldbox.h
+++ b/rle_goldbox.h
@@ -20,7 +20,7 @@ ssize_t goldbox_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_
 #ifdef RLE_ZOO_GOLDBOX_IMPLEMENTATION
 #include <assert.h>
 
-static_assert(sizeof(size_t) == sizeof(ssize_t));
+static_assert(sizeof(size_t) == sizeof(ssize_t), "");
 
 // return -(rp + 1) ... mask so it can't flip positive. Give up and just always return -1?
 #define RLE_ZOO_RETURN_ERR return ~(rp & ((size_t)~0 >> 1UL))

--- a/rle_goldbox.h
+++ b/rle_goldbox.h
@@ -20,7 +20,10 @@ ssize_t goldbox_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_
 #ifdef RLE_ZOO_GOLDBOX_IMPLEMENTATION
 #include <assert.h>
 
-#define RLE_ZOO_RETURN_ERR return ~rp
+static_assert(sizeof(size_t) == sizeof(ssize_t));
+
+// return -(rp + 1) ... mask so it can't flip positive. Give up and just always return -1?
+#define RLE_ZOO_RETURN_ERR return ~(rp & ((size_t)~0 >> 1UL))
 
 // RLE PARAMS: min CPY=1, max CPY=126, min REP=1, max REP=127
 ssize_t goldbox_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
@@ -28,6 +31,9 @@ ssize_t goldbox_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t 
 	size_t wp = 0;
 
 	while (rp < slen) {
+		assert((ssize_t)wp >= 0);
+		assert((ssize_t)rp >= 0);
+
 		uint8_t cnt = 0;
 
 		// Count number of same bytes, up to 126
@@ -63,7 +69,7 @@ ssize_t goldbox_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t 
 		if (dest) {
 			if (wp + cnt + 1 <= dlen) {
 				dest[wp] = cnt - 1;
-				for (int i = 0 ; i < cnt ; ++i)
+				for (unsigned int i = 0 ; i < cnt ; ++i)
 					dest[wp + 1 + i] = src[rp + i];
 			} else {
 				RLE_ZOO_RETURN_ERR;
@@ -74,13 +80,16 @@ ssize_t goldbox_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t 
 	}
 	assert(rp == slen);
 	assert((dest == NULL) || (wp <= dlen));
-	return wp;
+	return (ssize_t)wp;
 }
 
 ssize_t goldbox_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
 	size_t wp = 0;
 	size_t rp = 0;
 	while (rp < slen) {
+		assert((ssize_t)wp >= 0);
+		assert((ssize_t)rp >= 0);
+
 		uint8_t cnt;
 		uint8_t b = src[rp++];
 		if (b & 0x80) {
@@ -91,7 +100,7 @@ ssize_t goldbox_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_
 			}
 			if (dest) {
 				if (wp + cnt <= dlen) {
-					for (int i = 0 ; i < cnt ; ++i)
+					for (unsigned int i = 0 ; i < cnt ; ++i)
 						dest[wp + i] = src[rp];
 				} else {
 					RLE_ZOO_RETURN_ERR;
@@ -106,7 +115,7 @@ ssize_t goldbox_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_
 			}
 			if (dest) {
 				if (wp + cnt <= dlen) {
-					for (int i = 0 ; i < cnt ; ++i)
+					for (unsigned int i = 0 ; i < cnt ; ++i)
 						dest[wp + i] = src[rp + i];
 				} else {
 					RLE_ZOO_RETURN_ERR;
@@ -118,7 +127,7 @@ ssize_t goldbox_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_
 	}
 	assert(rp == slen);
 	assert((dest == NULL) || (wp <= dlen));
-	return wp;
+	return (ssize_t)wp;
 }
 #undef RLE_ZOO_RETURN_ERR
 #endif

--- a/rle_packbits.h
+++ b/rle_packbits.h
@@ -18,7 +18,7 @@ ssize_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size
 #ifdef RLE_ZOO_PACKBITS_IMPLEMENTATION
 #include <assert.h>
 
-static_assert(sizeof(size_t) == sizeof(ssize_t));
+static_assert(sizeof(size_t) == sizeof(ssize_t), "");
 
 // return -(rp + 1) ... mask so it can't flip positive. Give up and just always return -1?
 #define RLE_ZOO_RETURN_ERR return ~(rp & ((size_t)~0 >> 1UL))

--- a/rle_packbits.h
+++ b/rle_packbits.h
@@ -18,7 +18,10 @@ ssize_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size
 #ifdef RLE_ZOO_PACKBITS_IMPLEMENTATION
 #include <assert.h>
 
-#define RLE_ZOO_RETURN_ERR return ~rp
+static_assert(sizeof(size_t) == sizeof(ssize_t));
+
+// return -(rp + 1) ... mask so it can't flip positive. Give up and just always return -1?
+#define RLE_ZOO_RETURN_ERR return ~(rp & ((size_t)~0 >> 1UL))
 
 // RLE PARAMS: min CPY=1, max CPY=128, min REP=2, max REP=128
 ssize_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
@@ -26,6 +29,9 @@ ssize_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t
 	size_t wp = 0;
 
 	while (rp < slen) {
+		assert((ssize_t)wp >= 0);
+		assert((ssize_t)rp >= 0);
+
 		uint8_t cnt = 0;
 		do { ++cnt; } while ((rp + cnt + 1 <= rp + slen) && (cnt < 128) && (src[rp + cnt-1] == src[rp + cnt]));
 
@@ -34,7 +40,7 @@ ssize_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t
 			assert(cnt >= 2 && cnt <= 128);
 			if (dest) {
 				if (wp + 1 < dlen) {
-					dest[wp+0] = 257 - cnt;
+					dest[wp+0] = (uint8_t)(257 - cnt);
 					dest[wp+1] = src[rp];
 				} else {
 					RLE_ZOO_RETURN_ERR;
@@ -59,7 +65,7 @@ ssize_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t
 		if (dest) {
 			if (wp + cnt + 1 <= dlen) {
 				dest[wp] = cnt - 1;
-				for (int i = 0 ; i < cnt ; ++i)
+				for (unsigned int i = 0 ; i < cnt ; ++i)
 					dest[wp + 1 + i] = src[rp + i];
 			} else {
 				RLE_ZOO_RETURN_ERR;
@@ -70,24 +76,27 @@ ssize_t packbits_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t
 	}
 	assert(rp == slen);
 	assert((dest == NULL) || (wp <= dlen));
-	return wp;
+	return (ssize_t)wp;
 }
 
 ssize_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
 	size_t wp = 0;
 	size_t rp = 0;
 	while (rp < slen) {
+		assert((ssize_t)wp >= 0);
+		assert((ssize_t)rp >= 0);
+
 		uint8_t cnt = 0;
 		uint8_t b = src[rp++];
 		if (b > 0x80) {
 			// REP
-			cnt = 257 - b;
+			cnt = (uint8_t)(257 - b);
 			if (!(rp < slen)) {
 				RLE_ZOO_RETURN_ERR;
 			}
 			if (dest) {
 				if (wp + cnt <= dlen) {
-					for (int i = 0 ; i < cnt ; ++i)
+					for (unsigned int i = 0 ; i < cnt ; ++i)
 						dest[wp + i] = src[rp];
 				} else {
 					RLE_ZOO_RETURN_ERR;
@@ -102,7 +111,7 @@ ssize_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size
 			}
 			if (dest) {
 				if (wp + cnt <= dlen) {
-					for (int i = 0 ; i < cnt ; ++i)
+					for (unsigned int i = 0 ; i < cnt ; ++i)
 						dest[wp + i] = src[rp + i];
 				} else {
 					RLE_ZOO_RETURN_ERR;
@@ -114,7 +123,7 @@ ssize_t packbits_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size
 	}
 	assert(rp == slen);
 	assert((dest == NULL) || (wp <= dlen));
-	return wp;
+	return (ssize_t)wp;
 }
 #undef RLE_ZOO_RETURN_ERR
 #endif

--- a/rle_pcx.h
+++ b/rle_pcx.h
@@ -18,7 +18,7 @@ ssize_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dl
 #ifdef RLE_ZOO_PCX_IMPLEMENTATION
 #include <assert.h>
 
-static_assert(sizeof(size_t) == sizeof(ssize_t));
+static_assert(sizeof(size_t) == sizeof(ssize_t), "");
 
 // return -(rp + 1) ... mask so it can't flip positive. Give up and just always return -1?
 #define RLE_ZOO_RETURN_ERR return ~(rp & ((size_t)~0 >> 1UL))

--- a/rle_pcx.h
+++ b/rle_pcx.h
@@ -18,13 +18,19 @@ ssize_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dl
 #ifdef RLE_ZOO_PCX_IMPLEMENTATION
 #include <assert.h>
 
-#define RLE_ZOO_RETURN_ERR return ~rp
+static_assert(sizeof(size_t) == sizeof(ssize_t));
+
+// return -(rp + 1) ... mask so it can't flip positive. Give up and just always return -1?
+#define RLE_ZOO_RETURN_ERR return ~(rp & ((size_t)~0 >> 1UL))
 
 ssize_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
 	size_t rp = 0;
 	size_t wp = 0;
 
 	while (rp < slen) {
+		assert((ssize_t)wp >= 0);
+		assert((ssize_t)rp >= 0);
+
 		size_t cnt = 0;
 		// size_t cnt = rle_count_rep(src + rp, slen - rp, 63);
 		do { ++cnt; } while ((rp + cnt < slen) && (cnt < 63) && (src[rp + cnt - 1] == src[rp + cnt]));
@@ -34,7 +40,7 @@ ssize_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen
 			assert(cnt <= 63);
 			if (dest) {
 				if (wp + 1 < dlen) {
-					dest[wp+0] = 0xC0 | cnt;
+					dest[wp+0] = (uint8_t)(0xC0 | cnt);
 					dest[wp+1] = src[rp];
 				} else {
 					RLE_ZOO_RETURN_ERR;
@@ -58,13 +64,16 @@ ssize_t pcx_compress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen
 	}
 	assert(rp == slen);
 	assert((dest == NULL) || (wp <= dlen));
-	return wp;
+	return (ssize_t)wp;
 }
 
 ssize_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dlen) {
 	size_t wp = 0;
 	size_t rp = 0;
 	while (rp < slen) {
+		assert((ssize_t)wp >= 0);
+		assert((ssize_t)rp >= 0);
+
 		uint8_t cnt = 1;
 		uint8_t b = src[rp++];
 
@@ -78,7 +87,7 @@ ssize_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dl
 		}
 		if (dest) {
 			if (wp + cnt <= dlen) {
-				for (int i = 0 ; i < cnt ; ++i)
+				for (unsigned int i = 0 ; i < cnt ; ++i)
 					dest[wp + i] = b;
 			} else {
 				RLE_ZOO_RETURN_ERR;
@@ -88,7 +97,7 @@ ssize_t pcx_decompress(const uint8_t *src, size_t slen, uint8_t *dest, size_t dl
 	}
 	assert(rp == slen);
 	assert((dest == NULL) || (wp <= dlen));
-	return wp;
+	return (ssize_t)wp;
 }
 #undef RLE_ZOO_RETURN_ERR
 #endif

--- a/test_example.c
+++ b/test_example.c
@@ -5,8 +5,8 @@
 	See https://github.com/eloj/rle-zoo
 */
 #include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
+#include <stdint.h>
+#include <sys/types.h>
 
 #define RLE_ZOO_PACKBITS_IMPLEMENTATION
 #include "rle_packbits.h"
@@ -16,25 +16,20 @@ int main(void) {
 	size_t len = sizeof(input) - 1;
 
 	// Call with NULL for dest buffer to calculate output size.
-	ssize_t compressed_size = packbits_compress(input, len, NULL, 0);
+	// ssize_t compressed_size = packbits_compress(input, len, NULL, 0);
 
-	if (compressed_size > 0) {
-		uint8_t *output = malloc(compressed_size);
-		if (output) {
-			ssize_t res = packbits_compress(input, len, output, compressed_size);
-			if (res > 0) {
-				printf("Compressed '%s' (%zu bytes) into %zd bytes: ", input, len, compressed_size);
+	uint8_t dest[256];
+	ssize_t res = packbits_compress(input, len, dest, sizeof(dest));
+	if (res > 0) {
+		printf("Compressed '%s' (%zu bytes) into %zd bytes: ", input, len, res);
 
-				// Do something with the output.
-				for (int i = 0 ; i < res ; ++i) {
-					printf("%02X ", output[i]);
-				}
-				printf("\n");
-			} else {
-				printf("Compression error: %zd\n", res);
-			}
-			free(output);
+		// Do something with the output.
+		for (int i = 0 ; i < res ; ++i) {
+			printf("%02X ", dest[i]);
 		}
+		printf("\n");
+	} else {
+		printf("Compression error: %zd\n", res);
 	}
 	return 0;
 }

--- a/test_includeall.c
+++ b/test_includeall.c
@@ -1,0 +1,34 @@
+/*
+	RLE ZOO single-header library build test harness.
+	Copyright (c) 2022, Eddy L O Jansson. Licensed under The MIT License.
+
+	This progam exists to verify that all single-header codec libraries
+	build with no warnings, under some set of (strict) compiler warning flags.
+
+	See https://github.com/eloj/rle-zoo
+*/
+#include <stdio.h>
+#include <stdint.h>
+#include <sys/types.h>
+
+#define RLE_ZOO_GOLDBOX_IMPLEMENTATION
+#include "rle_goldbox.h"
+#define RLE_ZOO_PACKBITS_IMPLEMENTATION
+#include "rle_packbits.h"
+#define RLE_ZOO_PCX_IMPLEMENTATION
+#include "rle_pcx.h"
+
+int main(void) {
+	const uint8_t input[] = "ABBCCCDDDDEEEEE";
+	size_t len = sizeof(input) - 1;
+
+	ssize_t res = 0;
+
+	res += goldbox_compress(input, len, NULL, 0);
+	res += packbits_compress(input, len, NULL, 0);
+	res += pcx_compress(input, len, NULL, 0);
+
+	printf("%zd bytes required.\n", res);
+
+	return 0;
+}


### PR DESCRIPTION
Additional robustness changes to guard against overflow,
but we'll eventually document that you shouldn't pass SIZE_MAX/2 or
more data to the codecs in one go.

The rle_{variant}.h implementations now build under `-Wconversion`;
"Warn for implicit conversions that may alter a value", including
"conversions between signed and unsigned".

This is not the default in the Makefile, since none of the other code
builds with this flag. A more realistic target for tools may be to build
under `Wno-sign-conversion`, we'll see.